### PR TITLE
Update semver. Dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "colors": "^1.0.3",
     "commander": "^2.8.1",
     "fs-promise": "^0.3.1",
-    "semver": "^4.3.3"
+    "semver": "^5.0.0"
   },
   "devDependencies": {
     "babel": "^5.4.7",


### PR DESCRIPTION
There is only this change https://github.com/npm/node-semver/commit/41b56fa573d1ef0d1718777a8a21ae1b57ebcd83 in `semver`

Projects that use `mt-changelog` get such message
<img width="1052" alt="screen shot 2015-07-12 at 12 17 19 pm" src="https://cloud.githubusercontent.com/assets/847572/8637254/bb72b9d2-2890-11e5-84b8-6cce7b77fd5a.png">
