### PR TITLE
[fixed] provide missing promise implementation for env missing it

### DIFF
--- a/src/output.js
+++ b/src/output.js
@@ -1,4 +1,5 @@
 import fsp from 'fs-promise';
+import Promise from 'promise';
 
 export default function output({ stdout, filepath, formattedLog }) {
   if (stdout) {


### PR DESCRIPTION
I noticed this when working on a system with old node. I assume this has
never been a problem b/c most folks are running node that has Promise
natively. This actually addresses two issues. fs-promise requires a
promise lib (un documented peer) and this one line in output was relying
on native promise as well.
