### PR TITLE
Use updated 'release-script' which uses own './bin/changelog' now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v0.6.2 - Mon, 14 Sep 2015 20:52:47 GMT
+--------------------------------------
+
+- [a8deb3a](../../commit/a8deb3a) [added] 'release-script'
+- [00c3885](../../commit/00c3885) [fixed] provide missing promise implementation for env missing it
+- [c8d4ce8](../../commit/c8d4ce8) [fixed] provide missing promise implementation for env missing it
+
+
 <title not provided> - Mon, 01 Jun 2015 19:16:32 GMT
 ----------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "eslint-config-defaults": "^3.1.0",
     "eslint-plugin-mocha": "^0.4.0",
     "mocha": "^2.2.1",
-    "release-script": "^0.2.7",
-    "rf-changelog": "^0.4.0",
+    "release-script": "^0.2.8",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
     "tmp": "0.0.26"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mt-changelog",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "creates changelogs for git projects",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
instead of 'rf-changelog'
