### PR TITLE
Update 'release-script' to human friendly version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-defaults": "^3.1.0",
     "eslint-plugin-mocha": "^0.4.0",
     "mocha": "^2.2.1",
-    "release-script": "^0.2.8",
+    "release-script": "^0.5.0",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
     "tmp": "0.0.26"


### PR DESCRIPTION
Release script runs in "dry run" mode by default.
It prevents `danger` steps (`git push`, `npm publish` etc) from accidental running.

https://github.com/AlexKVal/release-script/pull/19/files
